### PR TITLE
Transition to the up-to-date Image Capture API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following emerging platform APIs are used by this collection of elements:
  - [Media Capture and Streams](https://www.w3.org/TR/mediacapture-streams/)
  - [MediaStream Recordering](https://www.w3.org/TR/mediastream-recording/)
  - [Web Audio API](https://www.w3.org/TR/webaudio/)
- - [MediaStream Image Capture](https://www.w3.org/TR/image-capture/)
+ - [MediaStream Image Capture](https://w3c.github.io/mediacapture-image/)
 
 Some additional browser support is enabled by the
 [WebRTC polyfill](https://github.com/webrtc/adapter). The following
@@ -243,7 +243,7 @@ call the `stop` method on the recorder instance.
 ### `<app-media-image-capture>`
 
 An emerging standard defines the
-[Image Capture API](https://www.w3.org/TR/image-capture/), which allows for
+[Image Capture API](https://w3c.github.io/mediacapture-image/), which allows for
 more fine-grained control of camera settings such as color temperature, white
 balance, focus and flash. It also allows for direct JPEG capture of the image
 that appears in a given media device.

--- a/app-media-image-capture.html
+++ b/app-media-image-capture.html
@@ -438,7 +438,6 @@ your app a reasonable fallback in browsers that do not natively support the API.
             // @see https://w3c.github.io/mediacapture-image/#redeyereduction-section
             if (this.redEyeReduction != null &&
                 this.photoCapabilities.redEyeReduction === 'controllable') {
-              photoSettings = photoSettings || {};
               photoSettings.redEyeReduction = this.redEyeReduction;
             }
 
@@ -456,43 +455,41 @@ your app a reasonable fallback in browsers that do not natively support the API.
          * supported values are ignored.
          */
         __generateConfigurationObject: function(reportedCapabilities, allowedNames) {
-          var configurationObject = null;
+          var configurationObject = {};
 
-          for (var i = 0; i < allowedNames.length; ++i) {
-            var name = allowedNames[i];
-            var value = this[name];
-            var capability = reportedCapabilities[name];
-            var capabilityIsArray = Array.isArray(capability);
+          if (reportedCapabilities != null) {
+            for (var i = 0; i < allowedNames.length; ++i) {
+              var name = allowedNames[i];
+              var value = this[name];
+              var capability = reportedCapabilities[name];
+              var capabilityIsArray = Array.isArray(capability);
 
-            // Don't set photo options if a value is provided, and skip
-            // if the name is not present in the PhotoCapabilities object
-            // (setting such properties will probably result in an error).
-            if (value == null ||
-                capability == null ||
-                capability === false ||
-                (capabilityIsArray && capability.indexOf(value) === -1)) {
-              continue;
-            }
-
-            if (configurationObject == null) {
-              configurationObject = {};
-            }
-
-            // If the capability is an object, then it is probably a
-            // MediaSettingsRange. This means we need to clamp the value to the
-            // min/max values of the range (otherwise it will likely throw when
-            // we try to apply the configuration).
-            // @see https://w3c.github.io/mediacapture-image/#mediasettingsrange
-            if (!capabilityIsArray &&
-                capability instanceof Object) {
-              if (capability.min >= value) {
-                value = capability.min;
-              } else if (capability.max <= value) {
-                value = capability.max;
+              // Don't set photo options if a value is provided, and skip
+              // if the name is not present in the PhotoCapabilities object
+              // (setting such properties will probably result in an error).
+              if (value == null ||
+                  capability == null ||
+                  capability === false ||
+                  (capabilityIsArray && capability.indexOf(value) === -1)) {
+                continue;
               }
-            }
 
-            configurationObject[name] = value;
+              // If the capability is an object, then it is probably a
+              // MediaSettingsRange. This means we need to clamp the value to the
+              // min/max values of the range (otherwise it will likely throw when
+              // we try to apply the configuration).
+              // @see https://w3c.github.io/mediacapture-image/#mediasettingsrange
+              if (!capabilityIsArray &&
+                  capability instanceof Object) {
+                if (capability.min >= value) {
+                  value = capability.min;
+                } else if (capability.max <= value) {
+                  value = capability.max;
+                }
+              }
+
+              configurationObject[name] = value;
+            }
           }
 
           return configurationObject;

--- a/app-media-image-capture.html
+++ b/app-media-image-capture.html
@@ -32,6 +32,13 @@ please consider including a polyfill such as
 Note that most polyfills will not enable full functionality, but they should give
 your app a reasonable fallback in browsers that do not natively support the API.
 
+ELEMENT DESIGN NOTE: Many of the properties of this element have a default
+configuration value of `null`. While this is weird, it is important to keep the
+behavior of multi-property observers in the element implementation normalized
+across Polymer 1.x and 2.x. Expect this aspect of the API to change as the
+element graduates from the current hybrid implementation to something that can
+rely on Polymer >=2.x observer semantics.
+
 @group App Elements
 @demo demo/index.html
 -->
@@ -411,6 +418,14 @@ your app a reasonable fallback in browsers that do not natively support the API.
           });
         },
 
+        /**
+         * ELEMENT DESIGN NOTE: While this observer does not rely on the
+         * arguments passed to it, it also avoids the pitfall of relying on
+         * properties that may be in a partial / indeterminant state at the
+         * time that its debounce'd implementation is invoked. As long as
+         * this remains true, it should not be subject to the undesirable
+         * behavior exhibited by some elements such as iron-selector.
+         */
         __updateTrackConstraints: function() {
           this.debounce('updateTrackConstraints', function() {
             var trackConstraints = this.__generateConfigurationObject(

--- a/app-media-image-capture.html
+++ b/app-media-image-capture.html
@@ -56,11 +56,9 @@ your app a reasonable fallback in browsers that do not natively support the API.
      * @see https://www.w3.org/TR/image-capture/#FillLightMode
      */
     Polymer.AppMedia.FillLightMode = {
-      UNAVAILABLE: 'unavailable',
       AUTO: 'auto',
       OFF: 'off',
-      FLASH: 'flash',
-      TORCH: 'torch'
+      FLASH: 'flash'
     };
 
     (function() {
@@ -69,13 +67,12 @@ your app a reasonable fallback in browsers that do not natively support the API.
         return;
       }
 
-      var PHOTO_SETTING_NAMES = [
+      var TRACK_CONSTRAINT_NAMES = [
         'whiteBalanceMode',
         'colorTemperature',
         'exposureMode',
         'exposureCompensation',
         'iso',
-        'redEyeReduction',
         'focusMode',
         'pointsOfInterest',
         'brightness',
@@ -83,9 +80,13 @@ your app a reasonable fallback in browsers that do not natively support the API.
         'saturation',
         'sharpness',
         'zoom',
+        'torch'
+      ];
+
+      var PHOTO_SETTING_NAMES = [
+        'fillLightMode',
         'imageHeight',
-        'imageWidth',
-        'fillLightMode'
+        'imageWidth'
       ];
 
       Polymer({
@@ -163,7 +164,7 @@ your app a reasonable fallback in browsers that do not natively support the API.
            * information about the minimum, maximum, current and incremental
            * values for various camera settings.
            *
-           * @see https://www.w3.org/TR/image-capture/#PhotoCapabilities
+           * @see https://w3c.github.io/mediacapture-image/##photocapabilities-section
            */
           photoCapabilities: {
             type: Object,
@@ -172,17 +173,27 @@ your app a reasonable fallback in browsers that do not natively support the API.
           },
 
           /**
+           * The MediaTrackCapabilities for the device providing the image data
+           * associated with the chosen video track. This object contains
+           * information about the minimum, maximum, current and incremental
+           * values for various camera settings.
+           *
+           * @see https://w3c.github.io/mediacapture-image/#mediatrackcapabilities-section
+           */
+          trackCapabilities: {
+            type: Object,
+            notify: true,
+            computed: '__computeTrackCapabilities(imageCapture, videoTrack)'
+          },
+
+          /**
            * The PhotoSettings that will be used to configure the ImageCapture
            * instance used by this element. This configuration is generated
            * based on the individually configured properties on this element.
            * A full list of configurable properties can be found
-           * [here](https://www.w3.org/TR/image-capture/#PhotoSettings).
+           * [here](https://w3c.github.io/mediacapture-image/##photosettings-section).
            *
-           * Note that if a given setting is not supported by the current input
-           * device, configuration will result in an exception. In order to
-           * ensure that only supported settings are set, wait for the
-           * photoCapabilities property to be updated and only set capabilities
-           * that are listed as keys in that object.
+           * @type {PhotoSettings}
            */
           photoSettings: {
             type: Object,
@@ -191,15 +202,62 @@ your app a reasonable fallback in browsers that do not natively support the API.
           },
 
           /**
-           * @type {Polymer.AppMedia.MeteringMode}
-           * @see https://www.w3.org/TR/image-capture/#PhotoSettings
+           * @type {Polymer.AppMedia.FillLightMode}
+           * @see https://w3c.github.io/mediacapture-image/##photosettings-section
            */
+          fillLightMode: {
+            type: String,
+            value: null
+          },
+
+          /** @see https://w3c.github.io/mediacapture-image/##photosettings-section */
+          imageHeight: {
+            type: Number,
+            value: null
+          },
+
+          /** @see https://w3c.github.io/mediacapture-image/##photosettings-section */
+          imageWidth: {
+            type: Number,
+            value: null
+          },
+
+          /**
+           * Note that red eye reduction may not be controllable. If it is reported as
+           * controllable, the value of this property will be respected. Otherwise it
+           * will be ignored.
+           *
+           * @see https://w3c.github.io/mediacapture-image/##photosettings-section
+           */
+          redEyeReduction: {
+            type: Boolean,
+            value: null
+          },
+
+          /**
+           * The constraints that will be applied to the MediaStreamTrack that
+           * is associated with the ImageCapture instance. This configuration is
+           * generated based on the individually configured properties on this
+           * element. A full list of configurable constraints can be found
+           * [here](https://w3c.github.io/mediacapture-image/#constrainable-properties)
+           *
+           * Note that if a given setting is not supported by the current track, it
+           * will be ignored. Also, any constraints that are suported will be clamped
+           * to the bounds that are reported by the track PhotoCapabilities instance.
+           */
+          trackConstraints: {
+            type: Object,
+            readOnly: true,
+            notify: true
+          },
+
+          /** @see https://w3c.github.io/mediacapture-image/#mediatracksettings-members */
           whiteBalanceMode: {
             type: String,
             value: null
           },
 
-          /** @see https://www.w3.org/TR/image-capture/#PhotoSettings */
+          /** @see https://w3c.github.io/mediacapture-image/#mediatracksettings-members */
           colorTemperature: {
             type: Number,
             value: null
@@ -207,102 +265,81 @@ your app a reasonable fallback in browsers that do not natively support the API.
 
           /**
            * @type {Polymer.AppMedia.MeteringMode}
-           * @see https://www.w3.org/TR/image-capture/#PhotoSettings
+           * @see https://w3c.github.io/mediacapture-image/#mediatracksettings-members
            */
           exposureMode: {
             type: String,
             value: null
           },
 
-          /** @see https://www.w3.org/TR/image-capture/#PhotoSettings */
+          /** @see https://w3c.github.io/mediacapture-image/#mediatracksettings-members */
           exposureCompensation: {
             type: Number,
             value: null
           },
 
-          /** @see https://www.w3.org/TR/image-capture/#PhotoSettings */
+          /** @see https://w3c.github.io/mediacapture-image/#mediatracksettings-members */
           iso: {
             type: Number,
             value: null
           },
 
-          /** @see https://www.w3.org/TR/image-capture/#PhotoSettings */
-          redEyeReduction: {
-            type: Boolean,
-            value: null
-          },
-
           /**
            * @type {Polymer.AppMedia.MeteringMode}
-           * @see https://www.w3.org/TR/image-capture/#PhotoSettings
+           * @see https://w3c.github.io/mediacapture-image/#mediatracksettings-members
            */
           focusMode: {
             type: String,
             value: null
           },
 
-          /** @see https://www.w3.org/TR/image-capture/#PhotoSettings */
+          /** @see https://w3c.github.io/mediacapture-image/#mediatracksettings-members */
           pointsOfInterest: {
             type: Array,
             value: null
           },
 
-          /** @see https://www.w3.org/TR/image-capture/#PhotoSettings */
+          /** @see https://w3c.github.io/mediacapture-image/#mediatracksettings-members */
           brightness: {
             type: Number,
             value: null
           },
 
-          /** @see https://www.w3.org/TR/image-capture/#PhotoSettings */
+          /** @see https://w3c.github.io/mediacapture-image/#mediatracksettings-members */
           contrast: {
             type: Number,
             value: null
           },
 
-          /** @see https://www.w3.org/TR/image-capture/#PhotoSettings */
+          /** @see https://w3c.github.io/mediacapture-image/#mediatracksettings-members */
           saturation: {
             type: Number,
             value: null
           },
 
-          /** @see https://www.w3.org/TR/image-capture/#PhotoSettings */
+          /** @see https://w3c.github.io/mediacapture-image/#mediatracksettings-members */
           sharpness: {
             type: Number,
             value: null
           },
 
-          /** @see https://www.w3.org/TR/image-capture/#PhotoSettings */
+          /** @see https://w3c.github.io/mediacapture-image/#mediatracksettings-members */
           zoom: {
             type: Number,
             value: null
           },
 
-          /** @see https://www.w3.org/TR/image-capture/#PhotoSettings */
-          imageHeight: {
-            type: Number,
-            value: null
-          },
-
-          /** @see https://www.w3.org/TR/image-capture/#PhotoSettings */
-          imageWidth: {
-            type: Number,
-            value: null
-          },
-
-          /**
-           * @type {Polymer.AppMedia.FillLightMode}
-           * @see https://www.w3.org/TR/image-capture/#PhotoSettings
-           */
-          fillLightMode: {
-            type: String,
+          /** @see https://w3c.github.io/mediacapture-image/#mediatracksettings-members */
+          torch: {
+            type: Boolean,
             value: null
           }
         },
 
         observers: [
-          '__updateImageCaptureOptions(imageCapture, photoSettings)',
           '__updatePhotoCapabilities(imageCapture, videoTrack)',
-          '__updatePhotoSettings(imageCapture, photoCapabilities, whiteBalanceMode, colorTemperature, exposureMode, exposureCompensation, iso, redEyeReduction, focusMode, pointsOfInterest, brightness, contrast, saturation, sharpness, zoom, imageHeight, imageWidth, fillLightMode)'
+          '__updatePhotoSettings(imageCapture, photoCapabilities, fillLightMode, imageHeight, imageWidth, redEyeReduction)',
+          '__updateTrackConstraints(imageCapture, trackCapabilities, whiteBalanceMode, exposureMode, focusMode, pointsOfInterest, exposureCompensation, colorTemperature, iso, brightness, contrast, saturation, sharpness, zoom, torch)'
         ],
 
         /**
@@ -316,10 +353,11 @@ your app a reasonable fallback in browsers that do not natively support the API.
             return Promise.reject(new Error('ImageCapture instance not ready.'));
           }
 
-          return this.imageCapture.takePhoto().then(function(photo) {
-            this._setLastPhoto(photo);
-            return photo;
-          }.bind(this));
+          return this.imageCapture.takePhoto(this.photoSettings)
+              .then(function(photo) {
+                this._setLastPhoto(photo);
+                return photo;
+              }.bind(this));
         },
 
         /**
@@ -353,34 +391,16 @@ your app a reasonable fallback in browsers that do not natively support the API.
           return new ImageCapture(videoTrack);
         },
 
-        __updatePhotoSettings: function() {
-          this.debounce('updatePhotoSettings', function() {
-            var photoSettings = null;
+        __computeTrackCapabilities: function(imageCapture, videoTrack) {
+          if (imageCapture == null || videoTrack == null) {
+            return;
+          }
 
-            for (var i = 0; i < PHOTO_SETTING_NAMES.length; ++i) {
-              var name = PHOTO_SETTING_NAMES[i];
-              var value = this[name];
-
-              // Don't set photo options if a value is provided, and skip
-              // if the name is not present in the PhotoCapabilities object
-              // (setting such properties will probably result in an error).
-              if (value == null || !(name in this.photoCapabilities)) {
-                continue;
-              }
-
-              if (!photoSettings) {
-                photoSettings = {};
-              }
-
-              photoSettings[name] = value;
-            }
-
-            this._setPhotoSettings(photoSettings);
-          });
+          return videoTrack.getCapabilities();
         },
 
         __updatePhotoCapabilities: function() {
-          this.debounce('updatePhotoSettings', function() {
+          this.debounce('updatePhotoCapabilities', function() {
             this.imageCapture.getPhotoCapabilities()
                 .then(function(photoCapabilities) {
                   this._setPhotoCapabilities(photoCapabilities);
@@ -391,20 +411,91 @@ your app a reasonable fallback in browsers that do not natively support the API.
           });
         },
 
-        __updateImageCaptureOptions: function() {
-          this.debounce('updateImageCaptureOptions', function() {
-            if (this.imageCapture == null || this.photoSettings == null) {
-              return;
+        __updateTrackConstraints: function() {
+          this.debounce('updateTrackConstraints', function() {
+            var trackConstraints = this.__generateConfigurationObject(
+                this.trackCapabilities, TRACK_CONSTRAINT_NAMES);
+
+            // TODO(cdata): It's not clear how constraints from one controller
+            // (such as this element) should attempt to compose with constraints
+            // from some other controller that has a reference to the same
+            // track. It's possible that we may benefit from some additional
+            // abstraction dedicated to managing constraints (or perhaps
+            // conflicts between controllers).
+            // @see https://www.w3.org/TR/mediacapture-streams/#dfn-applyconstraints
+            this._setTrackConstraints(trackConstraints);
+          });
+        },
+
+        __updatePhotoSettings: function() {
+          this.debounce('updatePhotoSettings', function() {
+            var photoSettings = this.__generateConfigurationObject(
+                this.photoCapabilities, PHOTO_SETTING_NAMES);
+
+            // Red eye reduction is a special case. The capability is reported
+            // as one of three states, and only one (controllable) allows the
+            // user to configure it.
+            // @see https://w3c.github.io/mediacapture-image/#redeyereduction-section
+            if (this.redEyeReduction != null &&
+                this.photoCapabilities.redEyeReduction === 'controllable') {
+              photoSettings = photoSettings || {};
+              photoSettings.redEyeReduction = this.redEyeReduction;
             }
 
-            this.imageCapture.setOptions(this.photoSettings)
-                .then(function() {
-                  this.fire('image-capture-options-updated', this);
-                }.bind(this))
-                .catch(function(e) {
-                  this.fire('image-capture-options-error', e);
-                }.bind(this));
+            this._setPhotoSettings(photoSettings);
           });
+        },
+
+        /**
+         * The purpose of this method is to take a set of capabilities reported
+         * by the platform, and sift the properties of this element through
+         * the filter of those reported capabilities. Properties that are not
+         * supported are ignored. Properties that are supported but don't have
+         * values within a MediaSettingsRange are clamped to that range.
+         * Properties with values that do not occur within a reported vector of
+         * supported values are ignored.
+         */
+        __generateConfigurationObject: function(reportedCapabilities, allowedNames) {
+          var configurationObject = null;
+
+          for (var i = 0; i < allowedNames.length; ++i) {
+            var name = allowedNames[i];
+            var value = this[name];
+            var capability = reportedCapabilities[name];
+            var capabilityIsArray = Array.isArray(capability);
+
+            // Don't set photo options if a value is provided, and skip
+            // if the name is not present in the PhotoCapabilities object
+            // (setting such properties will probably result in an error).
+            if (value == null ||
+                capability == null ||
+                capability === false ||
+                (capabilityIsArray && capability.indexOf(value) === -1)) {
+              continue;
+            }
+
+            if (configurationObject == null) {
+              configurationObject = {};
+            }
+
+            // If the capability is an object, then it is probably a
+            // MediaSettingsRange. This means we need to clamp the value to the
+            // min/max values of the range (otherwise it will likely throw when
+            // we try to apply the configuration).
+            // @see https://w3c.github.io/mediacapture-image/#mediasettingsrange
+            if (!capabilityIsArray &&
+                capability instanceof Object) {
+              if (capability.min >= value) {
+                value = capability.min;
+              } else if (capability.max <= value) {
+                value = capability.max;
+              }
+            }
+
+            configurationObject[name] = value;
+          }
+
+          return configurationObject;
         }
       });
     })();

--- a/test/app-media-image-capture.html
+++ b/test/app-media-image-capture.html
@@ -32,15 +32,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
-    <test-fixture id="configured">
+    <test-fixture id="configure-photo-settings">
       <template>
         <app-media-image-capture
-            exposure-mode="single-shot"
-            fill-light-mode="flash"
+            fill-light-mode="auto"
+            image-width="1024"
             red-eye-reduction>
         </app-media-image-capture>
       </template>
     </test-fixture>
+
+    <test-fixture id="configure-track-constraints">
+      <template>
+        <app-media-image-capture
+            iso="1600"
+            brightness="15"
+            focus="manual"
+            torch>
+        </app-media-image-capture>
+      </template>
+    </test-fixture>
+
 
     <script>
       suite('app-media-image-capture', function() {
@@ -54,11 +66,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         setup(function() {
           fakeImageCapture({
             capabilities: {
-              fillLightMode: true,
-              exposureMode: true
+              redEyeReduction: 'controllable',
+              fillLightMode: ['auto', 'off'],
             }
           });
-          stream = createFakeMediaStream({ videoTracks: 1 });
+          stream = createFakeMediaStream({
+            videoTracks: 1,
+            videoTrackCapabilities: {
+              brightness: {
+                min: 0,
+                max: 10,
+                step: 1
+              },
+
+              torch: true,
+
+              focusMode: [Polymer.AppMedia.MeteringMode.SINGLE_SHOT]
+            }
+          });
         });
 
         teardown(function() {
@@ -81,20 +106,44 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         suite('when photo settings are configured', function() {
           setup(function() {
-            element = fixture('configured');
+            element = fixture('configure-photo-settings');
             element.stream = stream;
             return awaitEvent(element, 'photo-settings-changed')
           });
 
           test('compiles settings into a photoSettings object', function() {
             expect(element.photoSettings).to.be.ok;
-            expect(element.photoSettings.exposureMode).to.be.equal('single-shot');
-            expect(element.photoSettings.fillLightMode).to.be.equal('flash');
+            expect(element.photoSettings.redEyeReduction).to.be.equal(true);
+            expect(element.photoSettings.fillLightMode).to.be.equal(Polymer.AppMedia.FillLightMode.AUTO);
           });
 
           test('ignores settings that are not supported', function() {
             expect(element.photoSettings).to.be.ok;
-            expect(element.photoSettings.redEyeReduction).to.be.equal(undefined);
+            expect(element.photoSettings.imageWidth).to.be.equal(undefined);
+          });
+        });
+
+        suite('when track constraints are configured', function() {
+          setup(function() {
+            element = fixture('configure-track-constraints');
+            element.stream = stream;
+            return awaitEvent(element, 'track-constraints-changed');
+          });
+
+          test('compiles constraints into a trackConstraints object', function() {
+            expect(element.trackConstraints).to.be.ok;
+            expect(element.trackConstraints.torch).to.be.equal(true);
+          });
+
+          test('clamps out of bounds values to allowed ranges', function() {
+            expect(element.trackConstraints).to.be.ok;
+            expect(element.trackConstraints.brightness).to.be.equal(10);
+          });
+
+          test('ignores constraints that are not supported', function() {
+            expect(element.trackConstraints).to.be.ok;
+            expect(element.trackConstraints.iso).to.be.equal(undefined);
+            expect(element.trackConstraints.focus).to.be.equal(undefined);
           });
         });
       });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -137,7 +137,12 @@
       var videoTracks = [];
 
       for (var i = 0; i < config.videoTracks; ++i) {
-        track = { stop: function() {} };
+        track = {
+          stop: function() {},
+          getCapabilities: function() {
+            return config.videoTrackCapabilities || {};
+          }
+        };
         videoTracks.push(track);
         tracks.push(track);
       }


### PR DESCRIPTION
I was referring to [the working draft](https://www.w3.org/TR/image-capture/) when implementing this element.

I should have referred to [the editor's draft](https://w3c.github.io/mediacapture-image/) instead.

Important changes:
 - Photo capabilities are now split between the capabilities of the `ImageCapture` instance and the capabilities of the video track that is being captured from.
 - The algorithm for detecting if a configuration will work as a setting or constraint is more robust. It now knows how to handle array and "range" capability types.
 - `redEyeDetection` is a weird one-off thing. You'll see what I mean in the code.
 - Added some tests for the new capability / constraint checking algorithm.