### PR TITLE
Add `api-supported` property to <app-media-image-capture>

### DIFF
--- a/app-media-image-capture.html
+++ b/app-media-image-capture.html
@@ -342,6 +342,16 @@ rely on Polymer >=2.x observer semantics.
           torch: {
             type: Boolean,
             value: null
+          },
+
+          /**
+           * Indicates whether `MediaStream Image Capture API` is supported or not.
+           */
+          apiSupported: {
+            type: Boolean,
+            readOnly: true,
+            notify: true,
+            value: 'ImageCapture' in window
           }
         },
 


### PR DESCRIPTION
Add `api-supported` property that indicates whether MediaStream Image Capture API is supported or not.