### PR TITLE
Various bug fixes and updates

### DIFF
--- a/app-media-stream.html
+++ b/app-media-stream.html
@@ -70,8 +70,7 @@ audio device into a media stream.
           stream: {
             type: Object,
             notify: true,
-            readOnly: true,
-            observer: '_streamChanged'
+            readOnly: true
           },
 
           /**
@@ -140,8 +139,15 @@ audio device into a media stream.
           if (this.active && this.constraints != null) {
             this.debounce('_updateStream', function() {
               var self = this;
+
               try {
-                this.__gettingUserMedia =
+                if (this.stream != null) {
+                  this.stream.getTracks().forEach(function(track) {
+                    track.stop();
+                  });
+                }
+
+                this.__gettingUserMedia = this.__gettingUserMedia ||
                     navigator.mediaDevices.getUserMedia(this.constraints)
                         .then(function(stream) {
                           self.__gettingUserMedia = null;
@@ -158,14 +164,6 @@ audio device into a media stream.
             }, 1);
           } else {
             this._setStream(null);
-          }
-        },
-
-        _streamChanged: function(stream, oldStream) {
-          if (oldStream != null) {
-            oldStream.getTracks().forEach(function(track) {
-              track.stop();
-            });
           }
         }
       })

--- a/app-media-video.html
+++ b/app-media-video.html
@@ -45,7 +45,9 @@ scaled video that is displayed to the viewer of the page.
         on-loadedmetadata="_updateMetrics"
         muted="[[muted]]"
         autoplay="[[autoplay]]"
-        loop="[[loop]]">
+        loop="[[loop]]"
+        webkit-playsinline
+        playsinline>
     </video>
   </template>
   <script>
@@ -221,6 +223,10 @@ scaled video that is displayed to the viewer of the page.
           // NOTE(cdata): No need to manually update metrics here, since the
           // new source will cause the video element to fire a loadmetadata
           // event when it is ready.
+
+          if (this.$.videoElement.paused) {
+            this.play();
+          }
         },
 
         _updateMetrics: function() {

--- a/demo/index.html
+++ b/demo/index.html
@@ -16,7 +16,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <title>app-media demo</title>
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-    <script src="../../webrtc-adapter/release/adapter.js"></script>
+    <script>
+      (function() {
+        window.ensureMediaDevices = new Promise(function(resolve) {
+          if (navigator.mediaDevices == null) {
+            var script = document.createElement('script');
+            script.src = '../../webrtc-adapter/release/adapter.js';
+            script.onload = resolve;
+            document.body.appendChild(script);
+          } else {
+            resolve();
+          }
+        });
+      })();
+    </script>
 
     <link rel="import" href="../../polymer/polymer.html">
     <link rel="import" href="../app-media-devices.html">
@@ -169,7 +182,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       </template>
       <script>
-        document.addEventListener('WebComponentsReady', function() {
+        var readyToDefine = Promise.all([
+          ensureMediaDevices,
+          new Promise(function(resolve) {
+            document.addEventListener('WebComponentsReady', resolve);
+          })
+        ]);
+
+        readyToDefine.then(function() {
           Polymer({
             is: 'x-video-camera',
 

--- a/test/app-media-stream.html
+++ b/test/app-media-stream.html
@@ -48,6 +48,39 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           test('yields a media stream', function() {
             expect(element.stream).to.be.okay;
           });
+
+          suite('when changing the constraints', function() {
+            setup(function() {
+              sinon.spy(navigator.mediaDevices, 'getUserMedia');
+            });
+
+            teardown(function() {
+              navigator.mediaDevices.getUserMedia.restore();
+            });
+
+            test('requests a new stream', function() {
+              element.videoDevice = createDevice('videoinput');
+              return awaitEvent(element, 'stream-changed')
+                  .then(function(event) {
+                    expect(navigator.mediaDevices
+                        .getUserMedia.callCount).to.be.eql(1);
+                  });
+            });
+
+            test('deactivates the old stream before requesting a new one',
+                function() {
+                  var stream = element.stream;
+                  var track = stream.getTracks()[0];
+
+                  sinon.spy(track, 'stop');
+                  element.videoDevice = createDevice('videoinput');
+
+                  return awaitEvent(element, 'stream-changed').then(
+                      function(event) {
+                        expect(track.stop.called).to.be.eql(true);
+                      });
+                });
+          });
         });
       });
     </script>

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -94,13 +94,13 @@
     };
   }
 
-  function awaitEvent(element, event, timeout) {
+  function awaitEvent(element, eventName, timeout) {
     timeout = timeout || 1000;
 
     return new Promise(function(resolve, reject) {
-      element.addEventListener(event, function listener() {
-        element.removeEventListener(event, listener);
-        resolve();
+      element.addEventListener(eventName, function listener(event) {
+        element.removeEventListener(eventName, listener);
+        resolve(event);
       });
 
       setTimeout(function() {


### PR DESCRIPTION
 - `<video>` requires playsinline attribute for iOS Safari
 - Ensures that `<video>` continues playing after its source has changes
 - Polyfill should be lazily loaded in demo
 - `MediaStream` tracks must be stopped when a new stream is created, or
 else an error will occur on some devices (such as Pixel XL)