### PR TITLE
Recorder mode for only announcing chunks

### DIFF
--- a/app-media-image-capture.html
+++ b/app-media-image-capture.html
@@ -459,7 +459,6 @@ rely on Polymer >=2.x observer semantics.
             // user to configure it.
             // @see https://w3c.github.io/mediacapture-image/#redeyereduction-section
             if (this.redEyeReduction != null &&
-                this.photoCapabilities &&
                 this.photoCapabilities.redEyeReduction === 'controllable') {
               photoSettings.redEyeReduction = this.redEyeReduction;
             }

--- a/app-media-image-capture.html
+++ b/app-media-image-capture.html
@@ -446,6 +446,11 @@ rely on Polymer >=2.x observer semantics.
 
         __updatePhotoSettings: function() {
           this.debounce('updatePhotoSettings', function() {
+            // Don't update anything until we know the available capabilities:
+            if (this.photoCapabilities == null) {
+              return;
+            }
+
             var photoSettings = this.__generateConfigurationObject(
                 this.photoCapabilities, PHOTO_SETTING_NAMES);
 
@@ -454,6 +459,7 @@ rely on Polymer >=2.x observer semantics.
             // user to configure it.
             // @see https://w3c.github.io/mediacapture-image/#redeyereduction-section
             if (this.redEyeReduction != null &&
+                this.photoCapabilities &&
                 this.photoCapabilities.redEyeReduction === 'controllable') {
               photoSettings.redEyeReduction = this.redEyeReduction;
             }

--- a/app-media-recorder.html
+++ b/app-media-recorder.html
@@ -161,6 +161,17 @@ you consider to be a suitable substitute, load it first and ensure that
             type: Boolean,
             value: false,
             notify: true
+          },
+
+          /**
+           * When set to true, the recorder will only dispatch `app-media-recorder-chunk`
+           * events, and will not keep a local cache of the data chunks that have been
+           * recorded. A consequence of this is that a final `data` Blob will not be
+           * available when the recording has finished.
+           */
+          onlyChunks: {
+            type: Boolean,
+            value: false
           }
         },
 
@@ -181,7 +192,10 @@ you consider to be a suitable substitute, load it first and ensure that
 
             if (event.data && event.data.size > 0) {
               this.fire('app-media-recorder-chunk', event.data);
-              data.push(event.data);
+
+              if (!this.onlyChunks) {
+                data.push(event.data);
+              }
             }
 
             if (this.duration > 0 && this.duration < elapsed && !finished) {
@@ -196,6 +210,12 @@ you consider to be a suitable substitute, load it first and ensure that
           var onStop = function() {
             this.recorder.removeEventListener('dataavailable', onDataAvailable);
             this.recorder.removeEventListener('stop', onStop);
+
+            this.fire('app-media-recorder-stopped');
+
+            if (this.onlyChunks) {
+              return;
+            }
 
             this._setData(new Blob(data, {
               type: this.mimeType

--- a/app-media-recorder.html
+++ b/app-media-recorder.html
@@ -169,7 +169,7 @@ you consider to be a suitable substitute, load it first and ensure that
            * recorded. A consequence of this is that a final `data` Blob will not be
            * available when the recording has finished.
            */
-          onlyChunks: {
+          disableBlobCache: {
             type: Boolean,
             value: false
           }
@@ -193,7 +193,7 @@ you consider to be a suitable substitute, load it first and ensure that
             if (event.data && event.data.size > 0) {
               this.fire('app-media-recorder-chunk', event.data);
 
-              if (!this.onlyChunks) {
+              if (!this.disableBlobCache) {
                 data.push(event.data);
               }
             }
@@ -213,7 +213,7 @@ you consider to be a suitable substitute, load it first and ensure that
 
             this.fire('app-media-recorder-stopped');
 
-            if (this.onlyChunks) {
+            if (this.disableBlobCache) {
               return;
             }
 

--- a/test/app-media-recorder.html
+++ b/test/app-media-recorder.html
@@ -115,14 +115,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         suite('with special configuration', function() {
-          suite('only chunks', function() {
+          suite('disabled blob cache', function() {
             var element;
 
             setup(function() {
               var recorder = fixture('basic');
 
               element = recorder.$.recorder;
-              element.onlyChunks = true;
+              element.disableBlobCache = true;
 
               return awaitEvent(element, 'recorder-changed');
             });

--- a/test/app-media-recorder.html
+++ b/test/app-media-recorder.html
@@ -39,6 +39,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </app-media-stream>
         <app-media-recorder id="recorder" stream="{{stream}}"></app-media-recorder>
       </template>
+
       <script>
         HTMLImports.whenReady(function() {
           Polymer({
@@ -63,6 +64,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script>
       suite('app-media-recorder', function() {
         var awaitEvent = AppMediaTestHelpers.awaitEvent;
+        var timePasses = AppMediaTestHelpers.timePasses;
         var createDevice = AppMediaTestHelpers.createDevice;
 
         setup(function() {
@@ -88,9 +90,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
             element.start();
 
-            Polymer.Base.async(function() {
+            timePasses(1).then(function() {
               element.stop();
-            }, 1);
+            });
 
             return dataChanges.then(function() {
               expect(element.data).to.be.instanceof(Blob);
@@ -102,12 +104,52 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
             element.recording = true;
 
-            Polymer.Base.async(function() {
+            timePasses().then(function() {
               element.recording = false;
             });
 
             return dataChanges.then(function() {
               expect(element.data).to.be.instanceof(Blob);
+            });
+          });
+        });
+
+        suite('with special configuration', function() {
+          suite('only chunks', function() {
+            var element;
+
+            setup(function() {
+              var recorder = fixture('basic');
+
+              element = recorder.$.recorder;
+              element.onlyChunks = true;
+
+              return awaitEvent(element, 'recorder-changed');
+            });
+
+            test('never records a data blob', function() {
+              var recorderStops = awaitEvent(element, 'app-media-recorder-stopped')
+                  .then(function() {
+                    // Give the `data-changed` event a chance to fire and
+                    // settle the corresponding check in the test:
+                    return timePasses(1);
+                  });
+              var dataChanges = awaitEvent(element, 'data-changed');
+              var dataChanged = false;
+
+              dataChanges.then(function() {
+                dataChanged = true;
+              });
+
+              element.recording = true;
+
+              timePasses(1).then(function() {
+                element.recording = false;
+              });
+
+              return recorderStops.then(function() {
+                expect(dataChanged).to.be.equal(false);
+              });
             });
           });
         });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -109,6 +109,12 @@
     });
   }
 
+  function timePasses(ms) {
+    return new Promise(function(resolve) {
+      Polymer.Base.async(resolve, ms);
+    });
+  }
+
   function createAudioMediaStream() {
     var context = new OfflineAudioContext(2,44100*40,44100);
     return context.createMediaStreamDestination().stream;
@@ -216,6 +222,7 @@
     restoreDevices: restoreDevices,
     createDevice: createDevice,
     awaitEvent: awaitEvent,
+    timePasses: timePasses,
     createAudioMediaStream: createAudioMediaStream,
     createFakeMediaStream: createFakeMediaStream,
     setRecorderData: setRecorderData,


### PR DESCRIPTION
This change adds a recorder mode where data chunks are not cached by the element. This relieves memory pressure at the expense of requiring the element user to assemble the chunks into a `Blob` by hand when recording is complete.

Also fixes a Polymer 2.x bug in `app-media-image-recorder` and related tests.