### PR TITLE
Fix polymer 2 bug in app-media-image-capture

### DIFF
--- a/app-media-image-capture.js
+++ b/app-media-image-capture.js
@@ -422,7 +422,7 @@ Polymer({
   },
 
   __computeImageCapture: function(videoTrack) {
-    if (!imageCaptureSupported) {
+    if (!imageCaptureSupported || !videoTrack) {
       return;
     }
 
@@ -438,7 +438,7 @@ Polymer({
   },
 
   __updatePhotoCapabilities: function() {
-    if (!imageCaptureSupported) {
+    if (!imageCaptureSupported || !this.imageCapture) {
       return;
     }
 


### PR DESCRIPTION
In polymer 2, observed properties can be undefined, so properly handle those cases. Fixes bug where "Failed to construct 'ImageCapture'" exception is thrown causing subsequent calls to takePhoto() to fail.

Fixes #59 