### PR TITLE
Explicitly set _template to null.

### DIFF
--- a/app-media-audio.js
+++ b/app-media-audio.js
@@ -20,6 +20,7 @@ analyser suitable for generating audio visualizations such as the ones made by
 */
 Polymer({
   is: 'app-media-audio',
+  _template: null,
 
   properties: {
     /**

--- a/app-media-devices.js
+++ b/app-media-devices.js
@@ -19,6 +19,7 @@ devices one at a time.
 */
 Polymer({
   is: 'app-media-devices',
+  _template: null,
 
   properties: {
     /**

--- a/app-media-image-capture.js
+++ b/app-media-image-capture.js
@@ -95,6 +95,7 @@ rely on Polymer >=2.x observer semantics.
 */
 Polymer({
   is: 'app-media-image-capture',
+  _template: null,
 
   properties: {
     /**

--- a/app-media-recorder.js
+++ b/app-media-recorder.js
@@ -57,6 +57,7 @@ you consider to be a suitable substitute, load it first and ensure that
 */
 Polymer({
   is: 'app-media-recorder',
+  _template: null,
 
   properties: {
     /**

--- a/app-media-stream.js
+++ b/app-media-stream.js
@@ -18,6 +18,7 @@ audio device into a media stream.
 */
 Polymer({
   is: 'app-media-stream',
+  _template: null,
 
   properties: {
     /**


### PR DESCRIPTION
This lets us skip a querySelector on initial bootup, and makes this code compatible with strictTemplatePolicy.

Part of internal change cl/218551336